### PR TITLE
Ignore log messages from registry healthcheck ping

### DIFF
--- a/stern.sh
+++ b/stern.sh
@@ -7,5 +7,6 @@ stern "migration-controller|migration-ui|registry|restic|velero" \
 --exclude "level=debug msg=.*s3aws.Stat" \
 --exclude "Found new dockercfg secret" \
 --exclude "Ignoring unrecognized environment variable REGISTRY" \
+--exclude "GET /v2/_catalog?n=5" \
 --since 5s \
 --kubeconfig ${CONFIGPATH} \


### PR DESCRIPTION
Related to https://github.com/konveyor/mig-controller/pull/681

Removes log spam from registry health checking every 5 seconds.