### PR TITLE
Watch all namespaces for label app.kubernetes.io/part-of=openshift-migration

### DIFF
--- a/stern.sh
+++ b/stern.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 CONFIGPATH=/var/cache/sa2kubeconfig/kubeconfig-${KSUFFIX}
 
-stern "migration-controller|migration-ui|restic|velero" \
+stern -l app.kubernetes.io/part-of=openshift-migration \
 --color ${STERN_COLOR} \
 --exclude-container discovery \
 --exclude "watch is too old"  \
 --exclude "Found new dockercfg secret" \
 --since 5s \
+--all-namespaces \
 --kubeconfig ${CONFIGPATH} \


### PR DESCRIPTION
Includes DVM rsync and stunnel pod logs in mig-log-reader.

PRs should merge at same time:
- https://github.com/konveyor/mig-controller/pull/1003
- https://github.com/konveyor/mig-operator/pull/613
- https://github.com/konveyor/mig-log-reader/pull/8

Resolves #3 