### PR TITLE
Filter noisy velero log messages

### DIFF
--- a/stern.sh
+++ b/stern.sh
@@ -11,6 +11,8 @@ stern -l app.kubernetes.io/part-of=openshift-migration \
 --exclude "No backup locations were ready to be verified" \
 --exclude "Backup cannot be garbage-collected" \
 --exclude "Error checking repository for stale locks" \
+--exclude "Backup has expired" \
+--exclude "error getting backup storage location" \
 --since 5s \
 --all-namespaces \
 --kubeconfig ${CONFIGPATH} \

--- a/stern.sh
+++ b/stern.sh
@@ -6,7 +6,7 @@ stern -l app.kubernetes.io/part-of=openshift-migration \
 --exclude-container discovery \
 --exclude "watch is too old"  \
 --exclude "Found new dockercfg secret" \
---exclude "backup location named \\\"default\\\" was not found" \
+--exclude "specified default backup location" \
 --exclude "needs to be at least 1 backup location" \
 --exclude "No backup locations were ready to be verified" \
 --exclude "Backup cannot be garbage-collected" \

--- a/stern.sh
+++ b/stern.sh
@@ -6,6 +6,11 @@ stern -l app.kubernetes.io/part-of=openshift-migration \
 --exclude-container discovery \
 --exclude "watch is too old"  \
 --exclude "Found new dockercfg secret" \
+--exclude "backup location named \\\"default\\\" was not found" \
+--exclude "needs to be at least 1 backup location" \
+--exclude "No backup locations were ready to be verified" \
+--exclude "Backup cannot be garbage-collected" \
+--exclude "Error checking repository for stale locks" \
 --since 5s \
 --all-namespaces \
 --kubeconfig ${CONFIGPATH} \


### PR DESCRIPTION
These log messages tend to repeat themselves every few seconds in the velero log whether a migration is running or not. I don't think they provide value, I think we should filter them.