### PR TITLE
reverting back to original approach of getting log

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,5 @@ do
     # Generate kubeconfig from SA token
     sa2kubeconfig.sh 1> /dev/null;
     # Run stern for 10 minutes then reboot
-    stern.sh;
+    timeout 10m stern.sh;
 done

--- a/stern.sh
+++ b/stern.sh
@@ -1,25 +1,19 @@
 #!/bin/bash
 CONFIGPATH=/var/cache/sa2kubeconfig/kubeconfig-${KSUFFIX}
 
-declare -a labels=("app.kubernetes.io/part-of=openshift-migration" "app.kubernetes.io/instance=velero" "name=restic")
-
-for i in "${labels[@]}"
-do
-    timeout 1m stern -l $i \
-    --color ${STERN_COLOR} \
-    --exclude-container discovery \
-    --exclude "watch is too old"  \
-    --exclude "Found new dockercfg secret" \
-    --exclude "specified default backup location" \
-    --exclude "needs to be at least 1 backup location" \
-    --exclude "No backup locations were ready to be verified" \
-    --exclude "Backup cannot be garbage-collected" \
-    --exclude "Error checking repository for stale locks" \
-    --exclude "Backup has expired" \
-    --exclude "error getting backup storage location" \
-    --exclude "There is no existing backup storage location set as default" \
-    --since 2m \
-    --all-namespaces \
-    --kubeconfig ${CONFIGPATH} \
-
-done
+stern -l app.kubernetes.io/part-of=openshift-migration \
+--color ${STERN_COLOR} \
+--exclude-container discovery \
+--exclude "watch is too old"  \
+--exclude "Found new dockercfg secret" \
+--exclude "specified default backup location" \
+--exclude "needs to be at least 1 backup location" \
+--exclude "No backup locations were ready to be verified" \
+--exclude "Backup cannot be garbage-collected" \
+--exclude "Error checking repository for stale locks" \
+--exclude "Backup has expired" \
+--exclude "error getting backup storage location" \
+--exclude "There is no existing backup storage location set as default" \
+--since 5s \
+--all-namespaces \
+--kubeconfig ${CONFIGPATH} \


### PR DESCRIPTION
We have the original label `app.kubernetes.io/part-of=openshift-migration` back on the respective pods, these PRs - [mig-legacy-operator](https://github.com/konveyor/mig-legacy-operator/pull/19) and [mig-operator](https://github.com/konveyor/mig-operator/pull/821) introduces the labels.